### PR TITLE
Better fix for invalid dir=... query parameter in git URLs

### DIFF
--- a/.version
+++ b/.version
@@ -1,1 +1,1 @@
-2.31.2-backcompat-3
+2.31.2-backcompat-4

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -182,10 +182,6 @@ struct GitInputScheme : InputScheme
                 name == "shallow" || name == "submodules" || name == "lfs" || name == "exportIgnore"
                 || name == "allRefs" || name == "verifyCommit" || name == "applyFilters")
                 attrs.emplace(name, Explicit<bool>{value == "1"});
-            else if (
-                name == "dir"
-            )
-                /* no op */;
             else
                 url2.query.emplace(name, value);
         }
@@ -223,8 +219,9 @@ struct GitInputScheme : InputScheme
         Input input{settings};
         input.attrs = attrs;
         auto url = fixGitURL(getStrAttr(attrs, "url"));
-        parseURL(url);
-        input.attrs["url"] = url;
+        auto parsedURL = parseURL(url);
+        parsedURL.query.erase("dir");
+        input.attrs["url"] = parsedURL.to_string();
         getShallowAttr(input);
         getSubmodulesAttr(input);
         getAllRefsAttr(input);


### PR DESCRIPTION
# Motivation

There is a code path that calls fetchTree via attributes and not via a string. These attributes can contain a "url" attribute which was passed unmodified to the git fetcher. Importantly it would call `inputFromAttrs` not `inputFromURL`, and the previous fix for this issue only impacted code paths that go via `inputFromURL`.  This change moves the fix to `inputFromAttrs`, but because `inputFromURL` also calls `inputFromAttrs`, it still fixes the `inputFromURL` code path too.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
