### PR TITLE
Support writing dir=... in flake.lock files

### DIFF
--- a/.version
+++ b/.version
@@ -1,1 +1,1 @@
-2.31.2-backcompat-4
+2.31.2-backcompat-6

--- a/src/libfetchers/attrs.cc
+++ b/src/libfetchers/attrs.cc
@@ -31,7 +31,7 @@ nlohmann::json attrsToJSON(const Attrs & attrs)
             json[attr.first] = *v;
         } else if (auto v = std::get_if<std::string>(&attr.second)) {
             if (attr.first == "url"
-                && !experimentalFeatureSettings.isEnabled(Xp::ModernNoDirQueryParamInFlakeLockUrlBehaviour)) {
+                && !experimentalFeatureSettings.isEnabled(Xp::ModernDirQueryParam)) {
                 // re-insert dir query parameter for backwards-compatibility
                 auto optionalDir = maybeGetStrAttr(attrs, "dir");
                 if (optionalDir) {

--- a/src/libfetchers/attrs.cc
+++ b/src/libfetchers/attrs.cc
@@ -30,7 +30,8 @@ nlohmann::json attrsToJSON(const Attrs & attrs)
         if (auto v = std::get_if<uint64_t>(&attr.second)) {
             json[attr.first] = *v;
         } else if (auto v = std::get_if<std::string>(&attr.second)) {
-            if (attr.first == "url" && !experimentalFeatureSettings.isEnabled(Xp::ModernNoDirQueryParamInFlakeLockUrlBehaviour)) {
+            if (attr.first == "url"
+                && !experimentalFeatureSettings.isEnabled(Xp::ModernNoDirQueryParamInFlakeLockUrlBehaviour)) {
                 // re-insert dir query parameter for backwards-compatibility
                 auto optionalDir = maybeGetStrAttr(attrs, "dir");
                 if (optionalDir) {

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -219,9 +219,8 @@ struct GitInputScheme : InputScheme
         Input input{settings};
         input.attrs = attrs;
         auto url = fixGitURL(getStrAttr(attrs, "url"));
-        auto parsedURL = parseURL(url);
-        parsedURL.query.erase("dir");
-        input.attrs["url"] = parsedURL.to_string();
+        parseURL(url);
+        input.attrs["url"] = url;
         getShallowAttr(input);
         getSubmodulesAttr(input);
         getAllRefsAttr(input);
@@ -489,6 +488,8 @@ struct GitInputScheme : InputScheme
                    Git interprets them as part of the file name. So get
                    rid of them. */
                 url.query.clear();
+            /* Strip dir attributes from the URL if they exist, they were written by older versions of nix */
+            url.query.erase("dir");
             repoInfo.location = url;
         }
 

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -24,7 +24,7 @@ struct ExperimentalFeatureDetails
  * feature, we either have no issue at all if few features are not added
  * at the end of the list, or a proper merge conflict if they are.
  */
-constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::LegacyNarBehaviour);
+constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::ModernNoDirQueryParamInFlakeLockUrlBehaviour);
 
 constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails = {{
     {
@@ -322,6 +322,18 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
 
             If set to `true`, `.gitattributes` files in git repos will be respected
             by the git fetcher. This is the behaviour of nix versions < 2.20.
+        )",
+        .trackingUrl = "",
+    },
+    {
+        .tag = Xp::ModernNoDirQueryParamInFlakeLockUrlBehaviour,
+        .name = "modern-no-dir-query-param-in-flake-lock-url-behaviour",
+        .description = R"(
+            If set to `false` (default), the flake inputs in flake.lock files using the
+            `dir` query parameter will have this included in the "url" attribute.
+
+            If set to `true`, the modern behaviour will be used where this query parameter is not
+            present in the "url" attribute.
         )",
         .trackingUrl = "",
     },

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -24,7 +24,7 @@ struct ExperimentalFeatureDetails
  * feature, we either have no issue at all if few features are not added
  * at the end of the list, or a proper merge conflict if they are.
  */
-constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::ModernNoDirQueryParamInFlakeLockUrlBehaviour);
+constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::ModernDirQueryParam);
 
 constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails = {{
     {
@@ -326,8 +326,8 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .trackingUrl = "",
     },
     {
-        .tag = Xp::ModernNoDirQueryParamInFlakeLockUrlBehaviour,
-        .name = "modern-no-dir-query-param-in-flake-lock-url-behaviour",
+        .tag = Xp::ModernDirQueryParam,
+        .name = "modern-dir-query-param",
         .description = R"(
             If set to `false` (default), the flake inputs in flake.lock files using the
             `dir` query parameter will have this included in the "url" attribute.

--- a/src/libutil/include/nix/util/experimental-features.hh
+++ b/src/libutil/include/nix/util/experimental-features.hh
@@ -38,6 +38,7 @@ enum struct ExperimentalFeature {
     PipeOperators,
     BLAKE3Hashes,
     LegacyNarBehaviour,
+    ModernNoDirQueryParamInFlakeLockUrlBehaviour,
 };
 
 /**


### PR DESCRIPTION
# Motivation

In order to generate flake.lock files that nix 2.18 does not consider to be out-of-date, we need to generate `?dir=...` query parameters in the `url` attribute of flake.lock files in the same way that nix 2.18 would. This behaviour is enabled by default, but can be disabled (reverting to the modern behaviour) if the experimental feature `modern-no-dir-query-param-in-flake-lock-url-behaviour` is enabled.

This PR also reverts https://github.com/GrahamDennis/nix/pull/3 with a better fix. Instead of removing the `dir` attribute when parsing a flake.lock file which may contain these attributes, we remove them much later when generating the url string to pass to `git` to fetch or clone a repo. I will will submit this part of the PR to nix upstream.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
