### PR TITLE
Add disable-implicit-final-fetch experimental feature

### DIFF
--- a/.version
+++ b/.version
@@ -1,1 +1,1 @@
-2.32.1-backcompat-7
+2.32.1-backcompat-8

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -341,7 +341,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
        FIXME: substituting may be slower than fetching normally,
        e.g. for fetchers like Git that are incremental!
     */
-    if (isFinal() && getNarHash()) {
+    if ((isFinal() || !experimentalFeatureSettings.isEnabled(Xp::DisableImplicitFinalFetch)) && getNarHash()) {
         try {
             auto storePath = computeStorePath(*store);
 

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -341,7 +341,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
        FIXME: substituting may be slower than fetching normally,
        e.g. for fetchers like Git that are incremental!
     */
-    if ((isFinal() || !experimentalFeatureSettings.isEnabled(Xp::DisableImplicitFinalFetch)) && getNarHash()) {
+    if ((isFinal() || !experimentalFeatureSettings.isEnabled(Xp::NoImplicitFinalFetch)) && getNarHash()) {
         try {
             auto storePath = computeStorePath(*store);
 

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -24,7 +24,7 @@ struct ExperimentalFeatureDetails
  * feature, we either have no issue at all if few features are not added
  * at the end of the list, or a proper merge conflict if they are.
  */
-constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::ModernDirQueryParam);
+constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::DisableImplicitFinalFetch);
 
 constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails = {{
     {
@@ -342,6 +342,18 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
 
             If set to `true`, the modern behaviour will be used where this query parameter is not
             present in the "url" attribute.
+        )",
+        .trackingUrl = "",
+    },
+    {
+        .tag = Xp::DisableImplicitFinalFetch,
+        .name = "disable-implicit-final-fetch",
+        .description = R"(
+            If set to `false` (default), the builtins.fetch* calls will behave as though they are
+            "final" if a narHash attribute is supplied.
+
+            If set to `true`, the unpatched behaviour will be used where builtins.fetch* will behave
+            as though the inputs are not "final" (unless final is explicitly supplied and supported in the future).
         )",
         .trackingUrl = "",
     },

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -24,7 +24,7 @@ struct ExperimentalFeatureDetails
  * feature, we either have no issue at all if few features are not added
  * at the end of the list, or a proper merge conflict if they are.
  */
-constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::DisableImplicitFinalFetch);
+constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::NoImplicitFinalFetch);
 
 constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails = {{
     {
@@ -346,8 +346,8 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .trackingUrl = "",
     },
     {
-        .tag = Xp::DisableImplicitFinalFetch,
-        .name = "disable-implicit-final-fetch",
+        .tag = Xp::NoImplicitFinalFetch,
+        .name = "no-implicit-final-fetch",
         .description = R"(
             If set to `false` (default), the builtins.fetch* calls will behave as though they are
             "final" if a narHash attribute is supplied.

--- a/src/libutil/include/nix/util/experimental-features.hh
+++ b/src/libutil/include/nix/util/experimental-features.hh
@@ -41,7 +41,7 @@ enum struct ExperimentalFeature {
     BLAKE3Hashes,
     LegacyNarBehaviour,
     ModernDirQueryParam,
-    DisableImplicitFinalFetch,
+    NoImplicitFinalFetch,
 };
 
 /**

--- a/src/libutil/include/nix/util/experimental-features.hh
+++ b/src/libutil/include/nix/util/experimental-features.hh
@@ -41,6 +41,7 @@ enum struct ExperimentalFeature {
     BLAKE3Hashes,
     LegacyNarBehaviour,
     ModernDirQueryParam,
+    DisableImplicitFinalFetch,
 };
 
 /**

--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -213,7 +213,7 @@ in
       cat_log()
 
       # Fetching with the resolved URL should produce the same result.
-      out2 = client.succeed(f"nix flake metadata {info['url']} --json --access-tokens github.com=ghp_000000000000000000000000000000000000 --tarball-ttl 0")
+      out2 = client.succeed(f"nix flake metadata {info['url']} --json --access-tokens github.com=ghp_000000000000000000000000000000000000 --tarball-ttl 0 --extra-experimental-features no-implicit-final-fetch")
       print(out2)
       info2 = json.loads(out2)
       print(info["fingerprint"], info2["fingerprint"])

--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -213,7 +213,9 @@ in
       cat_log()
 
       # Fetching with the resolved URL should produce the same result.
-      info2 = json.loads(client.succeed(f"nix flake metadata {info['url']} --json --access-tokens github.com=ghp_000000000000000000000000000000000000 --tarball-ttl 0"))
+      out2 = client.succeed(f"nix flake metadata {info['url']} --json --access-tokens github.com=ghp_000000000000000000000000000000000000 --tarball-ttl 0")
+      print(out2)
+      info2 = json.loads(out2)
       print(info["fingerprint"], info2["fingerprint"])
       assert info["fingerprint"] == info2["fingerprint"], "fingerprint mismatch"
 


### PR DESCRIPTION
# Motivation

Between Nix 2.18 and Nix 2.32, there is a performance regression in the difference in behaviour between flakes and the flake-compat library. Nix 2.32 fetches from upstream (e.g. git / tarballs) into the `~/.cache/nix` cache even if the result exists in `/nix/store` and we could know that because we have a NAR hash in our flake.lock file. Nix 2.18 just grabs the unpacked input from `/nix/store` [here](https://github.com/NixOS/nix/blob/2.18-maintenance/src/libfetchers/fetchers.cc#L118-L131), but Nix 2.32 won’t substitute unless `__final` is set ([see here](https://github.com/NixOS/nix/blob/2.32-maintenance/src/libfetchers/fetchers.cc#L327-L352)), but `__final` is set after getAccessorUnchecked is called ([see here](https://github.com/NixOS/nix/blob/2.32-maintenance/src/libfetchers/fetchers.cc#L209)). While `__final` is set when using the native flake nix features, it is not set via the flake-compat library because it just calls `builtins.fetchGit` / `builtins.fetchTarball` / etc which are all assumed to not be "final".

This PR is a short-term performance workaround which changes the default behaviour to treat input fetches as being final if a NAR hash is supplied/known. This behaviour can be _disabled_ by enabling the experimental feature `disable-implicit-final-fetch`.

The intended long-term option is for `builtins.fetch*` to support the `final` attribute and/or implicitly set `final = true` when "sufficient" attrs are provided, and "sufficient" should be defined such that the attrs coming from a flake lockfile are sufficient.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
