### PR TITLE
legacyNarBehaviour: Enable exportIgnore in legacy fetch mode for backwards compatibility with nix 2.18...

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -419,7 +419,8 @@ struct GitInputScheme : InputScheme
 
     bool getExportIgnoreAttr(const Input & input) const
     {
-        return maybeGetBoolAttr(input.attrs, "exportIgnore").value_or(false);
+        return maybeGetBoolAttr(input.attrs, "exportIgnore")
+            .value_or(maybeGetBoolAttr(input.attrs, "__legacy").value_or(false));
     }
 
     bool getAllRefsAttr(const Input & input) const

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -419,8 +419,11 @@ struct GitInputScheme : InputScheme
 
     bool getExportIgnoreAttr(const Input & input) const
     {
-        return maybeGetBoolAttr(input.attrs, "exportIgnore")
-            .value_or(maybeGetBoolAttr(input.attrs, "__legacy").value_or(false));
+        // exportIgnore is not supported if submodules=true, so even if __legacy is enabled, do not enable exportIgnore
+        // if submodules is enabled.
+        bool defaultIfNotConfigured =
+            maybeGetBoolAttr(input.attrs, "__legacy").value_or(false) && !getSubmodulesAttr(input);
+        return maybeGetBoolAttr(input.attrs, "exportIgnore").value_or(defaultIfNotConfigured);
     }
 
     bool getAllRefsAttr(const Input & input) const


### PR DESCRIPTION
## Motivation

The output of:

```
rm -rf ~/.cache/nix
nix eval --expr '(builtins.fetchTree { type = "git"; url = "ssh://git@github.com/jech/babeld"; rev = "950992f282d6139ce543f225564a35ac564ca1c2"; }).outPath'
```

is different for nix ~2.18 vs nix ~2.20, and as such is a breaking change.

* Nix 2.18 returns: `/nix/store/ykqz8vc311xgfvww23xdd18l6ffzpp2k-source`
* Nix ~2.20 returns: `/nix/store/glw5hj5vmbwmg6rzf4aqb53l7n5h9x81-source`
* After this PR with `legacy-nar-behaviour` enabled returns `/nix/store/ykqz8vc311xgfvww23xdd18l6ffzpp2k-source`

## Context

legacyNarBehaviour: Enable exportIgnore in legacy fetch mode for backwards compatibility with nix 2.18...

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
